### PR TITLE
fix(config): makes enums cacheable

### DIFF
--- a/config/basement.php
+++ b/config/basement.php
@@ -72,7 +72,7 @@ return [
     |
     */
 
-    'chat_box_widget_position' => ChatBoxPosition::bottomRight(),
+    'chat_box_widget_position' => (string) ChatBoxPosition::bottomRight(),
 
     /*
     |--------------------------------------------------------------------------
@@ -101,7 +101,7 @@ return [
     */
 
     'avatar' => [
-        'style' => AvatarStyle::micah(),
+        'style' => (string) AvatarStyle::micah(),
         'options' => [
             'b' => '%233584e4',
             'size' => 64,

--- a/src/Basement.php
+++ b/src/Basement.php
@@ -154,8 +154,7 @@ class Basement implements BasementContract
      */
     public static function getAvatarStyle(): AvatarStyle
     {
-        /** @var mixed $style */
-        $style = config('basement.avatar.style');
+        $style = AvatarStyle::tryFrom(config('basement.avatar.style'));
 
         if ($style instanceof AvatarStyle === false) {
             throw new \TypeError(
@@ -191,8 +190,7 @@ class Basement implements BasementContract
      */
     public static function getChatBoxWidgetPosition(): ChatBoxPosition
     {
-        /** @var mixed $position */
-        $position = config('basement.chat_box_widget_position');
+        $position = ChatBoxPosition::tryFrom(config('basement.chat_box_widget_position'));
 
         if ($position instanceof ChatBoxPosition === false) {
             throw new \TypeError(


### PR DESCRIPTION
This PR fixes errors when executing the `php artisan config:cache` command